### PR TITLE
Add support for jsonschema v4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'django',
         'jsonschema',
         'rfc3987',
-        'strict-rfc3339'
+        'rfc3339-validator'
     ],
     extras_require=dict(
         test=[


### PR DESCRIPTION
This pull request adds support for jsonschema [version 4.0.0](https://github.com/Julian/jsonschema/releases/tag/v4.0.0) released on 29 September 2021.

---

With jsonschema v4.x the tests for drf_jsonschema were breaking with the following exception:

```
drf_jsonschema/tests/test_convert.py:None (drf_jsonschema/tests/test_convert.py)
drf_jsonschema/tests/test_convert.py:998: in <module>
    class JSONSchemaFieldBasic(serializers.Serializer):
drf_jsonschema/tests/test_convert.py:999: in JSONSchemaFieldBasic
    foo = JSONSchemaField(schema={
drf_jsonschema/fields.py:27: in __init__
    self.validator = Draft4Validator(schema, types, resolver,
E   TypeError: __init__() takes from 2 to 4 positional arguments but 5 were given
```

The exception is caused by the library's usage of default types which were deprecated in jsonschema 3.x and removed in 4.x via https://github.com/Julian/jsonschema/commit/d9f6384. This pull request fixes the issue by adapting handling of JSONSchemaField's types parameter to the new [TypeChecker API](https://python-jsonschema.readthedocs.io/en/stable/validate/#type-checking) where possible.

After this fix, I noticed that the tests relying on the `data-time` format were failing. The test failure was caused by https://github.com/Julian/jsonschema/commit/622c7b2 which removed support for strict-rfc3339 (which this library listed out as a dependency) in favor of rfc3339-validator. To fix the issue, I updated the dependency appropriately.

---

I considered several other alternatives to the implementation in this pull request:

1. Using [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html) to get the version but this is only supported in Python 3.8+ or Python 3.6+ (via the [backport](https://importlib-metadata.readthedocs.io/en/latest/)) while this library lists Python 3.5+ as supported in the setup.py classifiers.

2. Using [inspect.signature](https://docs.python.org/3/library/inspect.html#inspect.signature) to look up the number of constructor arguments but this is brittle if new parameters are added in the future.

Overall I felt that catching the TypeError is the least impactful change as it avoids pulling in an additional dependency, it avoids dropping support for a specific Python version, and it will be forwards compatible to changes in the constructor signature. The downside is that in principle a TypeError could be caused by a different issue to the version mismatch, but ultimately I don't see a common use-case for TypeError being part of a constructor's API so this shouldn't be an issue in reality. Let me know if you disagree and I'm happy to code up another solution.