### PR TITLE
Fix DRF deprecation warning

### DIFF
--- a/drf_jsonschema/tests/test_convert.py
+++ b/drf_jsonschema/tests/test_convert.py
@@ -52,7 +52,7 @@ class BooleanFieldNotRequired(serializers.Serializer):
 
 @register
 class NullBooleanFieldBasic(serializers.Serializer):
-    foo = serializers.NullBooleanField()
+    foo = serializers.BooleanField(allow_null=True)
 
     json_schema = {
         "type": "object",


### PR DESCRIPTION
Running pytest in strict mode `py.test --strict-markers` shows a deprecation warning from Django Rest Framework:

```
RemovedInDRF314Warning: The `NullBooleanField` is deprecated and will be removed starting with 3.14.
Instead use the `BooleanField` field and set `allow_null=True` which does the same thing.
```

This pull request fixes the issue by following the migration path suggested by the warning.